### PR TITLE
Made attoparsec dependency more specific.

### DIFF
--- a/Snowdrift.cabal
+++ b/Snowdrift.cabal
@@ -131,7 +131,7 @@ library
                  , blaze-builder
                  , blaze-html
                  , blaze-markup
-                 , attoparsec
+                 , attoparsec                    >= 0.10.3.0    && < 0.11.0.0
                  , old-locale
                  , resourcet
                  , hit                           >= 0.5         && < 1.0


### PR DESCRIPTION
This avoids a build error due to an older version of attoparsec already
being installed globally.
