### PR TITLE
A rough version for wiki diffing (#12)

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -224,6 +224,8 @@ instance Yesod App where
     isAuthorized (DiscussCommentR target _) False = require wikiPageCanViewMeta target
 
     isAuthorized (WikiHistoryR target) _ = require wikiPageCanViewMeta target
+    isAuthorized (WikiDiffR target _ _) _ = require wikiPageCanViewMeta target
+    isAuthorized (WikiDiffProxyR target) _ = require wikiPageCanViewMeta target
     isAuthorized (WikiEditR target _) _ = require wikiPageCanViewMeta target
 
     isAuthorized route write = do

--- a/config/routes
+++ b/config/routes
@@ -51,6 +51,7 @@
 /w/#Text/history WikiHistoryR GET
 /w/#Text/history/#WikiEditId WikiEditR GET
 /w/#Text/diff/#WikiEditId/#WikiEditId WikiDiffR GET
+/w/#Text/diffp WikiDiffProxyR GET
 
 /newcomments WikiNewCommentsR GET
 /newedits WikiNewEditsR GET

--- a/templates/wiki_history.hamlet
+++ b/templates/wiki_history.hamlet
@@ -1,25 +1,27 @@
 <div .row>
     <div .span9>
         <div .row>
-            <table .table>
-                $forall Entity edit_id edit <- edits
+            <form action="@{WikiDiffProxyR target}" method="GET">
+                <table .table>
+                    $forall Entity edit_id edit <- edits
+                        <tr>
+                            <td>
+                                <a href="@{WikiEditR target edit_id}">
+                                    ^{renderTime (wikiEditTs edit)}
+                            <td>
+                                $with user_id <- wikiEditUser edit
+                                    $maybe user <- M.lookup user_id users
+                                        <a href="@{UserR user_id}">
+                                            #{userPrintName user}
+                            <td>
+                                $maybe comment <- wikiEditComment edit
+                                    #{comment}
+                            <td>
+                                <input type="radio" name="start" value="#{toPathPiece edit_id}">
+                                <input type="radio" name="end" value="#{toPathPiece edit_id}">
                     <tr>
+                        <td colspan="3">
                         <td>
-                            <a href="@{WikiEditR target edit_id}">
-                                ^{renderTime (wikiEditTs edit)}
-                        <td>
-                            $with user_id <- wikiEditUser edit
-                                $maybe user <- M.lookup user_id users
-                                    <a href="@{UserR user_id}">
-                                        #{userPrintName user}
-                        <td>
-                            $maybe comment <- wikiEditComment edit
-                                #{comment}
-                        <td>
-                            Diff against revision:
-                            $forall Entity other_edit_id other_edit <- edits
-                                $with comment <- wikiEditComment other_edit
-                                    <a href="@{WikiDiffR target other_edit_id edit_id}" $maybe title="#{fromMaybe "" comment}">
-                                        #{toPathPiece other_edit_id}
+                            <input type="submit" value="diff">
     <div .span3>
         ^{sidebar}

--- a/templates/wiki_history.hamlet
+++ b/templates/wiki_history.hamlet
@@ -12,9 +12,14 @@
                                 $maybe user <- M.lookup user_id users
                                     <a href="@{UserR user_id}">
                                         #{userPrintName user}
-                        $maybe comment <- wikiEditComment edit
-                            <td>
+                        <td>
+                            $maybe comment <- wikiEditComment edit
                                 #{comment}
-
+                        <td>
+                            Diff against revision:
+                            $forall Entity other_edit_id other_edit <- edits
+                                $with comment <- wikiEditComment other_edit
+                                    <a href="@{WikiDiffR target other_edit_id edit_id}" $maybe title="#{fromMaybe "" comment}">
+                                        #{toPathPiece other_edit_id}
     <div .span3>
         ^{sidebar}


### PR DESCRIPTION
Adds two radio buttons next to each wiki revision; selecting one from each column and clicking "show diff" goes to the "ugly" diff URL (?start=1&end=2) which then redirects to the "nice" diff URL (/1/2).

This version is fully working, but it lacks a few things: you can currently request reverse diffs (/2/1), and "identity" diffs (/1/1), this should be caught and handled in the WikiDiffR handler (and maybe WikiDiffProxyR too). There should also be some JS to enhance the client-side experience.

There is no reverting diffs yet, and the "quick diff" functionality hasn't been implemented either.
