### PR TITLE
/admin/license and /projectsignup

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -48,11 +48,13 @@ import Handler.Home
 import Handler.HonorPledge
 import Handler.Invitation
 import Handler.JsLicense
+import Handler.License
 import Handler.MarkdownTutorial
 import Handler.Notification
 import Handler.PostLogin
 import Handler.Privacy
 import Handler.Project
+import Handler.ProjectSignup
 import Handler.RepoFeed
 import Handler.ToU
 import Handler.User
@@ -95,6 +97,7 @@ makeApplication conf = do
     foundation <- makeFoundation conf
 
     -- Initialize the logging middleware
+    user_id <- requireAuthId
     logWare <- mkRequestLogger def
         { outputFormat =
             if development

--- a/Handler/License.hs
+++ b/Handler/License.hs
@@ -1,0 +1,102 @@
+module Handler.License where
+
+import Import
+import Model.License
+--import Data.Maybe
+import Data.ByteString as S
+import Data.ByteString.Lazy as L
+--import Control.Monad.Trans.Resource
+--import Control.Monad.ST
+import Data.Conduit
+import Data.Conduit.Binary
+
+licenseEntryForm :: Html -> MForm Handler (FormResult LicenseFormData, Widget)
+licenseEntryForm lefHtml = do
+    (licenseNameRes, licenseNameView) <- mreq textField (generateFieldSettings "LicenseName" [("class", "form-control"), ("placeholder", "License Name")]) Nothing
+    (licenseClassificationRes, licenseClassificationView) <- mreq (selectFieldList getLicenseClassificationTypes) (generateFieldSettings "Classification" [("class", "form-control"), ("placeholder", "License Classification")]) Nothing
+    (licenseProjectTypeRes, licenseProjectTypeView) <- mreq (selectFieldList getLicenseProjectTypes) (generateFieldSettings "ProjectType" [("class", "form-control"), ("placeholder", "Project Type")]) Nothing
+    (licenseOptionsRes, licenseOptionsView) <- mopt textareaField (generateFieldSettings "Options" [("class", "form-control"), ("placeholder", "License Options")]) Nothing
+    (licenseWebsiteRes, licenseWebsiteView) <- mreq textField (generateFieldSettings "Website" [("class", "form-control"), ("placeholder", "Web Link to Legal Text")]) Nothing
+    (licenseIconRes, licenseIconView) <- mopt fileField (generateFieldSettings "UploadIcon" [("class", "form-control")]) Nothing
+
+    let licenseEntryRes = LicenseFormData
+                        <$> licenseNameRes
+                        <*> licenseClassificationRes
+                        <*> licenseProjectTypeRes
+                        <*> licenseOptionsRes
+                        <*> licenseWebsiteRes
+                        <*> licenseIconRes
+    let widget = toWidget $(widgetFile "license_entry")
+    return (licenseEntryRes, widget)
+
+
+getLicenseEntryR :: Handler Html
+getLicenseEntryR = do
+    ((_, widget), enctype) <- runFormGet licenseEntryForm
+    defaultLayout $ do
+        setTitle "License Entry | Snowdrift.coop"
+        [whamlet|
+            <H1 Align="center">
+                Snowdrift.coop - Admin Site
+            <H3 Align="center">
+                License Entry Form
+            <form .form-horizontal method=POST action=@{LicenseEntryR} enctype=#{enctype}>
+                ^{widget}
+                <input type=submit>
+        |]
+
+extractImage :: Maybe FileInfo -> Handler(Maybe S.ByteString)
+extractImage Nothing  = (return Nothing) :: Handler(Maybe S.ByteString)
+extractImage (Just x) = fmap (Just . toStrict) ((fileSource x $$ sinkLbs) :: Handler L.ByteString)
+
+
+postLicenseEntryR :: Handler Html
+postLicenseEntryR = do
+    ((result, widget), enctype) <- runFormPostNoToken $ licenseEntryForm
+    case result of
+        FormSuccess l -> do
+            limage <- extractImage $ lfdImage l
+            let license = License {
+                              licenseName = lfdName l
+                            , licenseClassification = lfdClassification l
+                            , licenseProjectType = lfdProjectType l
+                            , licenseOptions = lfdOptions l
+                            , licenseWebsite = lfdWebsite l
+                            , licenseImage = limage
+                            }
+
+            runDB $ insert_ license
+            defaultLayout $ do
+                setTitle "Successful License Entry | Snowdrift.coop" 
+                [whamlet|<H1 Align="Center">License Entered
+                         <br>
+                         <p>#{licenseName license} has been added to the database.
+                         <form method=GET action=@{LicenseEntryR} enctype=#{enctype}>
+                            <button>Enter another License
+                |]
+        
+        FormFailure messages -> defaultLayout $ do
+            setTitle "License Entry Failure | Snowdrift.coop"
+            [whamlet|
+                 <H1 Align="Center">License Error(s):
+                 <br>
+                 <ul>
+                    $forall message <- messages
+                         <li>#{message}
+                 <br>
+                <form .form-horizontal method=POST action=@{LicenseEntryR} enctype=#{enctype}>
+                    ^{widget}
+                    <input type=submit>
+            |]
+        
+        FormMissing -> defaultLayout $ do
+            setTitle "License Entry | Snowdrift.coop"
+            [whamlet|
+                <H1 Align="center">
+                    Snowdrift.coop - Admin Site
+                <H3 Align="center">
+                    License Entry Form
+                <form .form-horizontal method=POST action=@{LicenseEntryR} enctype=#{enctype}>
+                    ^{widget}
+                    <input type=submit>
+            |]

--- a/Handler/ProjectSignup.hs
+++ b/Handler/ProjectSignup.hs
@@ -1,0 +1,162 @@
+module Handler.ProjectSignup where
+
+import Import
+
+import Model.ProjectSignup
+import Model.License
+
+projectSignupForm :: UserId -> Html -> MForm Handler (FormResult ProjectSignup, Widget)
+projectSignupForm user_id _ = do
+    licenses <- lift $ runDB getLicenses
+
+    (projectNameRes, projectNameView) <- mreq textField (generateFieldSettings "Project Name" [("class", "form-control"), ("placeholder", "Project Name")]) Nothing
+    (projectHandleRes, projectHandleView) <- mreq textField (generateFieldSettings "Project Handle" [("class", "form-control")]) Nothing
+    (projectWebsiteRes, projectWebsiteView) <- mopt textField (generateFieldSettings "Website" [("class", "form-control"), ("placeholder", "Project Website")]) Nothing
+    (projectTypeRes, projectTypeView) <- mreq (multiSelectFieldList getProjectTypes) (generateFieldSettings "Project Type" [("class", "form-control"), ("placeholder", "Project Type(s)")]) Nothing
+    (projectTypeOtherRes, projectTypeOtherView) <- mopt textField (generateFieldSettings "ProjectTypeOther" [("class", "form-control"), ("placeholder", "Describe Other Project Type")]) Nothing
+    (projectLicenseRes, projectLicenseView) <- mreq (multiSelectFieldList $ getLicenseLabels licenses) (generateFieldSettings "License" [("class", "form-control"), ("placeholder", "Select License(s)")]) Nothing
+    (projectLicenseOtherRes, projectLicenseOtherView) <- mopt textField (generateFieldSettings "ProjectLicenseOther" [("class", "form-control"), ("placeholder", "Describe Other License Type")]) Nothing
+    (projectHistoryRes, projectHistoryView) <- mreq textField (generateFieldSettings "ProjectHistory" [("class", "form-control"), ("placeholder", "Length of time project has been active")]) Nothing
+    (projectLocationRes, projectLocationView) <- mreq textField (generateFieldSettings "Location" [("class", "form-control"), ("placeholder", "Location Project is legally based out of")]) Nothing
+    (projectLegalStatusRes, projectLegalStatusView) <- mreq (selectFieldList getLegalStatuses) (generateFieldSettings "Legal Status" [("class", "form-control"), ("placeholder", "Legal Status of Project")]) Nothing
+    (projectLegalStatusCommentsRes, projectLegalStatusCommentsView) <- mopt textField (generateFieldSettings "Legal Status Comments" [("class", "form-control"), ("placeholder", "Additional Comments about Legal Status")]) Nothing
+    (projectUserRoleRes, projectUserRoleView) <- mreq textField (generateFieldSettings "User Role" [("class", "form-control"), ("placeholder", "Describe your role within the project")]) Nothing
+    (projectMissionRes, projectMissionView) <- mreq textareaField (generateFieldSettings "Mission" [("class", "form-control"), ("placeholder", "Describe your project's vision and mission")]) Nothing
+    (projectGoalsRes, projectGoalsView) <- mreq textareaField (generateFieldSettings "Goals" [("class", "form-control"), ("placeholder", "Describe your project's short-term and long-term goals and deliverables")]) Nothing
+    (projectFundsRes, projectFundsView) <- mreq textareaField (generateFieldSettings "Funds" [("class", "form-control"), ("placeholder", "Describe how your project will benefit from and make use of funds raised through Snowdrift.coop")]) Nothing
+    (projectOtherInfoRes, projectOtherInfoView) <- mopt textareaField (generateFieldSettings "Other Info" [("class", "form-control"), ("placeholder", "Please provide any additional information you find pertinent here (e.g. other contacts affiliated with the project and their contact info)")]) Nothing
+
+    let projectSignupRes = ProjectSignup 
+                <$> projectNameRes
+                <*> projectHandleRes
+                <*> projectWebsiteRes
+                <*> projectTypeRes
+                <*> projectTypeOtherRes
+                <*> projectLicenseRes
+                <*> projectLicenseOtherRes
+                <*> projectHistoryRes
+                <*> projectLocationRes
+                <*> projectLegalStatusRes
+                <*> projectLegalStatusCommentsRes
+                <*> projectUserRoleRes
+                <*> projectMissionRes
+                <*> projectGoalsRes 
+                <*> projectFundsRes
+                <*> projectOtherInfoRes
+                <*> pure user_id
+                <*> pure newProjectSignupStatus
+    let widget = toWidget $(widgetFile "project_signup")
+    return (projectSignupRes, widget)
+
+
+getProjectSignupR :: Handler Html
+getProjectSignupR = do
+    user_id <- requireAuthId
+    ((_, widget), enctype) <- runFormGet (projectSignupForm user_id)
+    defaultLayout $ do
+        setTitle "Project Signup Form | Snowdrift.coop"
+        [whamlet|
+            <H1 align="center">
+                Snowdrift.coop
+            <H3 align="center">
+                Project SignUp Form
+            <form method=POST action=@{ProjectSignupR} enctype=#{enctype}>
+                ^{widget}
+                <button>Submit Application
+        |]
+
+postProjectSignupR :: Handler Html
+postProjectSignupR = do
+    user_id <- requireAuthId
+    ((result, widget), enctype) <- runFormPostNoToken (projectSignupForm user_id)
+    case result of
+        FormSuccess project -> do
+          [ Value projectcheck :: Value Int64 ] <- runDB $ select $ from $ \a -> do
+              where_ (a ^. ProjectHandle ==. val (projectSignupHandle project))
+              return $ count (a ^. ProjectHandle)
+              
+          projectsubmitted <- if projectcheck > 0
+                                then return Nothing
+                                else runDB $ insertUnique project
+
+          if isJust projectsubmitted
+              then defaultLayout $ do
+                      setTitle "Project Signup Form: Success! | Snowdrift.coop"
+                      [whamlet|
+                          <H1 Align=Center>Success!
+                          <br>
+                          <p>Your application to add #{projectSignupName $ project} has been submitted for review by the Snowdrift administrators to validate that your project meets the standards for Snowdrift.  You will receive a response within 7 - 10 business days.
+                          <p>If your application is approved, your project's default Snowdrift page will be created for you, at which point you can edit the content as you see fit.
+                          <p>If your application is rejected, you will receive an e-mail explaining why your project does not meet Snowdrift's criteria.  
+                          <H3 Align=Center>Thank you for your interest in Snowdrift!!
+                          <form method=GET action=@{HomeR} enctype=#{enctype}>
+                              <button>Return Home
+                      |]
+              
+              else defaultLayout $ do
+                  setTitle "Project Signup Form: Submission Error! | Snowdrift.coop"
+                  [whamlet|
+                      <H1 Align=Center>Submission Error
+                      <ul>
+                          <li color=red>#{projectSignupName $ project} already exists on Snowdrift.  You may have already submitted a sign-up request, which is still under review.
+                      <form method=GET action=@{ProjectSignupR} enctype=#{enctype}>
+                          <button>Return to previous form
+                  |]
+
+        FormFailure messages -> defaultLayout $ do
+                setTitle "Project Signup Form: Submission Error! | Snowdrift.coop"
+                [whamlet|
+                    <H1 Align=Center>Submission Error
+                    <ul>
+                        $forall message <- messages
+                            <li color=red>#{message}
+                    <br>
+                    <form .form-horizontal method=POST action=@{ProjectSignupR} enctype=#{enctype}>
+                        ^{widget}
+                        <button>Submit Application
+                |]
+                
+        FormMissing -> defaultLayout $ do
+                setTitle "Project Signup Form | Snowdrift.coop"
+                [whamlet|
+                <form method=POST enctype=#{enctype}>
+                    ^{widget}
+                    <button>Submit Application
+                |]
+
+applicationReviewForm :: Entity ProjectSignup -> Html -> MForm Handler (FormResult ReviewerComments, Widget)
+applicationReviewForm project _ = do
+    (reviewerCommentRes, reviewerCommentView) <- mopt textField (generateFieldSettings "Reviewer Comment" [("class", "form-control"), ("placecholder", "Enter Comments Here")]) Nothing 
+    (reviewerStatusRes, reviewerStatusView) <- mreq (selectFieldList projectSignupStatus) (generateFieldSettings "Reviewer Status" [("class", "form-control")]) Nothing
+
+    let reviewerCommentRes = ReviewerComment
+        <$> pure $ ProjectSignupId project
+        <*> lift (liftIO getCurrentTime)
+        <*> reviewerCommentRes
+        <*> reviewerStatusRes
+        <*> 
+
+    let widget = toWidget $(widgetFile "application_review")
+    defaultLayout $ do
+        setTitle "Application Review: #{ProjectSignupName project} | Snowdrift.coop"
+        ^{widget}
+        <button>Update
+
+getProjectApplicationR :: ProjectSignupId -> Handler Html
+getProjectApplicationR = do
+    user_id <- requireAuthId
+    if(userIsProjectAdminDB user_id (projectId getSiteProject))
+        then
+            project <- runDB $ select $ from \p -> do
+                where_ (p ^. ProjectSignupId ==. val (ps_id))
+                return p
+            ((_, widget), enctype) <- runFormGet project
+
+getProjectApplicationsR :: Handler Html
+getProjectApplicationsR = do
+    user_id <- requireAuthId
+    project <- runDB $ select $ from \p -> do
+        where_ (p ^. ProjectSignupStatus ==. val (InReview))
+        limit 1
+        return p
+    ((_, widget), enctype) <- runFormGet project

--- a/Model.hs
+++ b/Model.hs
@@ -2,27 +2,30 @@
 
 module Model where
 
-import Model.Comment.Internal      (FlagReason, Visibility)
-import Model.Currency              (Milray)
-import Model.Established.Internal  (Established(..))
-import Model.Markdown.Diff         (MarkdownDiff)
-import Model.Notification.Internal (NotificationType, NotificationDelivery)
-import Model.Permission.Internal   (PermissionLevel)
-import Model.Role.Internal         (Role)
-import Model.Settings.Internal     (UserSettingName)
-import Model.ViewType.Internal     (ViewType)
+import Model.Comment.Internal       (FlagReason, Visibility)
+import Model.Currency               (Milray)
+import Model.Established.Internal   (Established(..))
+import Model.Markdown.Diff          (MarkdownDiff)
+import Model.Notification.Internal  (NotificationType, NotificationDelivery)
+import Model.Permission.Internal    (PermissionLevel)
+import Model.Role.Internal          (Role)
+import Model.Settings.Internal      (UserSettingName)
+import Model.ViewType.Internal      (ViewType)
+import Model.ProjectSignup.Internal (ProjectType, ProjectSignupStatus)
+import Model.License.Internal       (LicenseClassificationType, LicenseProjectType, LegalStatus)
 
-import Control.Exception           (Exception)
-import Data.Int                    (Int64)
-import Data.Function               (on)
-import Data.Text                   (Text)
-import Data.Time.Clock             (UTCTime)
-import Data.Typeable               (Typeable)
+import Control.Exception            (Exception)
+import Data.ByteString              (ByteString)
+import Data.Int                     (Int64)
+import Data.Function                (on)
+import Data.Text                    (Text)
+import Data.Time.Clock              (UTCTime)
+import Data.Typeable                (Typeable)
 import Database.Persist.Quasi
 import Prelude
 import Yesod
-import Yesod.Auth.HashDB           (HashDBUser (..))
-import Yesod.Markdown              (Markdown)
+import Yesod.Auth.HashDB            (HashDBUser (..))
+import Yesod.Markdown               (Markdown)
 
 -- You can define all of your database entities in the entities file.
 -- You can find more information on persistent and how to declare entities
@@ -45,3 +48,12 @@ instance Exception DBException where
 
 instance Ord Project where
     compare = compare `on` projectName
+
+
+generateFieldSettings :: Text -> [(Text, Text)] -> FieldSettings a
+generateFieldSettings name attrs = FieldSettings { fsLabel = SomeMessage name
+                                                 , fsTooltip = Just (SomeMessage name)
+                                                 , fsName = Just name
+                                                 , fsId = Just name
+                                                 , fsAttrs = attrs
+                                                 }

--- a/Model.hs
+++ b/Model.hs
@@ -11,7 +11,7 @@ import Model.Permission.Internal    (PermissionLevel)
 import Model.Role.Internal          (Role)
 import Model.Settings.Internal      (UserSettingName)
 import Model.ViewType.Internal      (ViewType)
-import Model.ProjectSignup.Internal (ProjectType, ProjectSignupStatus)
+import Model.ProjectSignup.Internal (ProjectType, ProjectSignupStatus(..))
 import Model.License.Internal       (LicenseClassificationType, LicenseProjectType, LegalStatus)
 
 import Control.Exception            (Exception)

--- a/Model/License.hs
+++ b/Model/License.hs
@@ -1,0 +1,51 @@
+module Model.License where
+
+import Model.License.Internal
+import Import
+import Data.List as L
+
+data LicenseFormData = LicenseFormData {
+                        lfdName :: Text
+                        , lfdClassification :: LicenseClassificationType
+                        , lfdProjectType :: LicenseProjectType
+                        , lfdOptions :: Maybe Textarea
+                        , lfdWebsite :: Text
+                        , lfdImage :: Maybe FileInfo
+                        } 
+
+getLicenseClassificationLabel :: LicenseClassificationType -> Text
+getLicenseClassificationLabel lct = case lct of
+                                     CopyLeft -> "CopyLeft"
+                                     CopyFree -> "CopyFree"
+                                     OtherClassification -> "Other"
+
+getLicenseClassificationTypes :: [(Text, LicenseClassificationType)]
+getLicenseClassificationTypes = L.map (getLicenseClassificationLabel &&& id) ([minBound .. maxBound] :: [LicenseClassificationType])
+
+getLicenseProjectTypes :: [(Text, LicenseProjectType)]
+getLicenseProjectTypes = L.map (getLicenseProjectLabel &&& id) ([minBound .. maxBound] :: [LicenseProjectType])
+
+getLicenseProjectLabel :: LicenseProjectType -> Text
+getLicenseProjectLabel x = case x of
+                              SoftwareLicense -> "Software License"
+                              NonSoftwareLicense -> "Non-Software License"
+                              AnyLicense -> "Software & Non-Software License"
+
+
+getLegalStatuses :: [(Text, LegalStatus)]
+getLegalStatuses = L.map (getLegalStatusLabel &&& id) ([minBound .. maxBound] :: [LegalStatus])
+
+getLegalStatusLabel :: LegalStatus -> Text
+getLegalStatusLabel x = case x of
+                            Unincorporated -> "Unincorporated"
+                            CoopNonProfit -> "Cooperative Non-Profit"
+                            OtherNonProfit -> "Other Non-Profit"
+                            BenefitCorp -> "Benefit Corporation"
+                            ForProfit -> "Other For-Profit"
+
+
+getLicenses :: SqlPersistT Handler [Entity License]
+getLicenses = selectList [] [Asc LicenseName]
+
+getLicenseLabels :: [Entity License] -> [(Text, LicenseId)]
+getLicenseLabels l = L.map ((licenseName . entityVal) &&& entityKey) l

--- a/Model/License/Internal.hs
+++ b/Model/License/Internal.hs
@@ -1,0 +1,16 @@
+module Model.License.Internal where
+import Prelude
+import Database.Persist.TH
+import Yesod.Core
+import Data.Text
+import Yesod.Form.Fields 
+
+
+data LicenseClassificationType = CopyLeft | CopyFree | OtherClassification deriving (Read, Show, Eq, Ord, Bounded, Enum)
+derivePersistField "LicenseClassificationType"
+
+data LicenseProjectType = SoftwareLicense | NonSoftwareLicense | AnyLicense deriving (Read, Show, Eq, Ord, Bounded, Enum)
+derivePersistField "LicenseProjectType"
+
+data LegalStatus = Unincorporated | CoopNonProfit | OtherNonProfit | BenefitCorp | ForProfit deriving (Read, Show, Eq, Ord, Bounded, Enum)
+derivePersistField "LegalStatus"

--- a/Model/ProjectSignup.hs
+++ b/Model/ProjectSignup.hs
@@ -21,6 +21,15 @@ getProjectTypeLabel pt = case pt of
 getProjectTypes :: [(Text, ProjectType)]
 getProjectTypes = L.map (getProjectTypeLabel &&& id) ([minBound .. maxBound] :: [ProjectType])
 
+getProjectSignupStatusLabel :: ProjectSignupStatus -> Text
+getProjectSignupStatusLabel pss = case pss of
+                                InReview -> "In Review"
+                                Approved -> "Approved"
+                                Denied -> "Denied"
+
+getProjectSignupStatuses :: [(Text, ProjectSignupStatus)]
+getProjectSignupStatuses = L.map (getProjectSignupStatusLabel &&& id) ([minBound .. maxBound] :: [ProjectSignupStatus])
+
 newProjectSignupStatus :: ProjectSignupStatus
 newProjectSignupStatus = InReview
 

--- a/Model/ProjectSignup.hs
+++ b/Model/ProjectSignup.hs
@@ -1,0 +1,26 @@
+module Model.ProjectSignup where
+
+import Model.ProjectSignup.Internal
+import Import
+import Data.List as L
+
+getProjectTypeLabel :: ProjectType -> Text
+getProjectTypeLabel pt = case pt of
+                            Art -> "Visual Art"
+                            CreativeWriting -> "Creative Writing"
+                            Education -> "Educational"
+                            Games -> "Games"
+                            Hardware -> "Hardware Designs"
+                            Journalism -> "Journalism"
+                            Music -> "Music"
+                            Software -> "Software"
+                            Research -> "Research"
+                            Video -> "Video"
+                            OtherProjectType -> "Other"
+
+getProjectTypes :: [(Text, ProjectType)]
+getProjectTypes = L.map (getProjectTypeLabel &&& id) ([minBound .. maxBound] :: [ProjectType])
+
+newProjectSignupStatus :: ProjectSignupStatus
+newProjectSignupStatus = InReview
+

--- a/Model/ProjectSignup/Internal.hs
+++ b/Model/ProjectSignup/Internal.hs
@@ -1,0 +1,9 @@
+module Model.ProjectSignup.Internal where
+import Prelude
+import Database.Persist.TH
+
+data ProjectType = CreativeWriting | Education | Games | Hardware | Journalism | Music | Research | Software | Video | Art | OtherProjectType deriving (Read, Show, Eq, Ord, Bounded, Enum)
+derivePersistField "ProjectType"
+
+data ProjectSignupStatus = InReview | Approved | Denied deriving (Read, Show, Eq, Ord, Bounded, Enum)
+derivePersistField "ProjectSignupStatus"

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ postgres=# alter user snowdrift_development with encrypted password 'YOURPASSPHR
 postgres=# alter user snowdrift_test with encrypted password 'YOURPASSPHRASE';
 postgres=# grant all privileges on database snowdrift_development to snowdrift_development;
 postgres=# update pg_database set datistemplate=true where datname='snowdrift_test_template';
-vi config/postgres.yml // set 'password' to 'YOURPASSPHRASE', same as you chose above
+vi config/postgresql.yml // set 'password' to 'YOURPASSPHRASE', same as you chose above
 sudo -u postgres psql snowdrift_development <devDB.sql
 sudo -u postgres psql snowdrift_test_template <testDB.sql
 
 // Hack away
+cabal install yesod-bin
 yesod devel
 ```

--- a/Snowdrift.cabal
+++ b/Snowdrift.cabal
@@ -39,11 +39,13 @@ library
                      Model.Currency
                      Model.Discussion
                      Model.Issue
+                     Model.License
                      Model.Markdown
                      Model.Markdown.Diff
                      Model.Notification
                      Model.Permission
                      Model.Project
+                     Model.ProjectSignup
                      Model.Project.Sql
                      Model.Role
                      Model.Settings
@@ -70,11 +72,13 @@ library
                      Handler.HonorPledge
                      Handler.Invitation
                      Handler.JsLicense
+                     Handler.License
                      Handler.MarkdownTutorial
                      Handler.Notification
                      Handler.PostLogin
                      Handler.Privacy
                      Handler.Project
+                     Handler.ProjectSignup
                      Handler.RepoFeed
                      Handler.ToU
                      Handler.User
@@ -149,6 +153,7 @@ library
                  , bytestring
                  , clientsession
                  , conduit
+                 , conduit-extra
                  , containers
                  , data-default
                  , diagrams

--- a/config/models
+++ b/config/models
@@ -120,6 +120,7 @@ ProjectSignup
     funds Textarea
     otherInfo Textarea Maybe
     user UserId
+    currentStatus ProjectSignupStatus
     UniqueProjectSignupHandle handle
 
 ReviewerComments

--- a/config/models
+++ b/config/models
@@ -102,6 +102,41 @@ Project
 
     deriving Eq Show
 
+ProjectSignup
+    name Text
+    handle Text
+    website Text Maybe
+    projectType [ProjectType]
+    projectTypeOther Text Maybe
+    license [LicenseId]
+    licenseOther Text Maybe
+    history Text
+    location Text
+    legalStatus LegalStatus
+    legalStatusComments Text Maybe
+    userRoleInProject Text
+    mission Textarea
+    goals Textarea
+    funds Textarea
+    otherInfo Textarea Maybe
+    user UserId
+    UniqueProjectSignupHandle handle
+
+ReviewerComments
+    ps_id ProjectSignupId
+    timestamp UTCTime
+    comment Text
+    status ProjectSignupStatus
+    reviewer UserId
+
+License
+    name Text
+    classification LicenseClassificationType
+    projectType LicenseProjectType
+    options Textarea Maybe
+    website Text 
+    image ByteString Maybe
+
 ProjectBlog
     time          UTCTime
     title         Text

--- a/config/routes
+++ b/config/routes
@@ -77,6 +77,8 @@
 /p/#ProjectId/watch   WatchProjectR   POST
 /p/#ProjectId/unwatch UnwatchProjectR POST
 
+/projectsignup ProjectSignupR GET POST
+
 -- Project wiki
 
 /p/#Text/w/#Text                              WikiR                 GET POST
@@ -113,6 +115,12 @@
 
 /dev/repo  RepoFeedR  GET
 /dev/build BuildFeedR GET
+
+-- Admin Pages
+/admin/licenses LicenseEntryR GET POST
+/admin/projectapplication ProjectApplicationsR GET
+/admin/projectapplication/#ProjectSignupId ProjectApplicationR GET
+
 
 -- DEPRECATED
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 Default: &defaults
   host: "127.0.0.1"
   port: 3000
-  approot: "http://localhost:3000"
+  approot: "http://50.198.210.110:3000"
   copyright: "2012-2014 Snowdrift.coop"
   source: "https://gitorious.org/snowdrift/snowdrift"
   githubrepo: "dlthomas/snowdrift"

--- a/templates/application_review.hamlet
+++ b/templates/application_review.hamlet
@@ -42,18 +42,18 @@
                     Select Applicable Project Type(s):
             <div .col-md-4>
                     <ul>
-                        $forall pt <- projectSignupType project
+                        $forall pt <- projectSignupProjectType project
                             <li>#{pt}
     <div .row>
         <div .form-group>
             <div .col-md-1>
                 <label>If Other, please describe:
             <div .col-md-4>
-                <input type=text disabled readonly>#{projectLicenseOther project}
+                <input type=text disabled readonly>#{projectSignupLicenseOther project}
             <div .col-md-offset-1 .col-md-1>
                 <label>If Other, please describe:
             <div .col-md-4>
-                <input type=text disabled readonly>#{projectTypeOther project}
+                <input type=text disabled readonly>#{projectSignupProjectTypeOther project}
 <br>
 <fieldset>
     <legend>
@@ -63,18 +63,18 @@
             <div .col-md-2>
                 <label>Location Project is legally based out of:
             <div .col-md-3>
-                <input type=text disabled readonly>#{projectLocation project}
+                <input type=text disabled readonly>#{projectSignupLocation project}
             <div .col-md-offset-1 .col-md-2>
                 <label>
                     Legal Status:
             <div .col-md-4>
-                <input type=text disabled readonly>#{projectLegalStatus project}
+                <input type=text disabled readonly>#{projectSignupLegalStatus project}
     <div .row>
         <div .form-group>
             <div .col-md-2>
                 <label>Additional Comments about Legal Status:
             <div .col-md-10>
-                <input type=text disabled readonly>#{projectLegalStatusComments project}
+                <input type=text disabled readonly>#{projectSignupLegalStatusComments project}
 <br>
 <fieldset>
     <legend>
@@ -84,29 +84,29 @@
             <div .col-md-2>
                 <label>Describe your role within the project
             <div .col-md-10>
-                <textarea disabled readonly>#{projectUserRole project}
+                <textarea disabled readonly>#{projectSignupUserRoleInProject project}
     <div .row>
         <div .form-group>
             <div .col-md-2>
                 <label>Describe your project's vision and mission:
             <div .col-md-10>
-                <textarea disabled readonly>#{projectMission project}
+                <textarea disabled readonly>#{projectSignupMission project}
     <div .row>
         <div .form-group>
             <div .col-md-2>
                 <label>Describe your project's short-term and long-term goals and deliverables:
             <div .col-md-10>
-                <textarea disabled readonly>#{projectGoals project}
+                <textarea disabled readonly>#{projectSignupGoals project}
     <div .row>
         <div .form-group>
             <div .col-md-2>
                 <label>Describe how your project will benefit from and make use of funds raised through Snowdrift.coop:
             <div .col-md-10>
-                <textarea disabled readonly>#{projectFunds project}
+                <textarea disabled readonly>#{projectSignupFunds project}
     <div .row>
         <div .form-group>
             <div .col-md-2>
                 <label>Please provide any additional information you find pertinent here (e.g. other contacts affiliated with the project and their contact info)
             <div .col-md-10>
-                <textarea disabled readonly>#{projectOtherInfo project}
+                <textarea disabled readonly>#{projectSignupOtherInfo project}
 <br>

--- a/templates/application_review.hamlet
+++ b/templates/application_review.hamlet
@@ -1,0 +1,112 @@
+<h1 align=center>Snowdrift.coop
+<h3 align=center>Project Application Review
+<br>
+
+<fieldset>
+    <legend>
+        General Project Info
+    <div .row>
+        <div .form-group>
+            <div .col-md-1>
+                <label>Project Name:
+            <div .col-md-4>
+                <input type=text disabled readonly>#{ProjectSignupName project}
+            <div .col-md-offset-1 .col-md-1>
+                <label>Website:
+            <div .col-md-5>
+                <input type=url disabled readonly>#{ProjectSignupWebsite project}
+    <div .row>
+        <div .form-group>
+            <div .col-md-1>
+                <label>Requested Site Handle:
+            <div .col-sm-4>
+                <div .row>
+                    <div .col-md-6 align=bottom>
+                        <font size=-1>
+                            http://snowdrift.coop/p/#{ProjectSignupHandle project}
+            <div .col-md-offset-1 .col-md-1>
+                <label>Length of time project's been active:
+            <div .col-md-5>
+                <input type=text disabled readonly>#{ProjectSignupHistory project}
+    <div .row>
+        <div .form-group>
+            <div .col-md-1>
+                <label>
+                    Select Applicable Project License(s):
+            <div .col-md-4>
+                <ul>
+                    $forall license <- projectSignupLicense project
+                        <li>#{license}
+            <div .col-md-offset-1 .col-md-1>
+                <label>
+                    Select Applicable Project Type(s):
+            <div .col-md-4>
+                    <ul>
+                        $forall pt <- projectSignupType project
+                            <li>#{pt}
+    <div .row>
+        <div .form-group>
+            <div .col-md-1>
+                <label>If Other, please describe:
+            <div .col-md-4>
+                <input type=text disabled readonly>#{projectLicenseOther project}
+            <div .col-md-offset-1 .col-md-1>
+                <label>If Other, please describe:
+            <div .col-md-4>
+                <input type=text disabled readonly>#{projectTypeOther project}
+<br>
+<fieldset>
+    <legend>
+        Legal Information
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Location Project is legally based out of:
+            <div .col-md-3>
+                <input type=text disabled readonly>#{projectLocation project}
+            <div .col-md-offset-1 .col-md-2>
+                <label>
+                    Legal Status:
+            <div .col-md-4>
+                <input type=text disabled readonly>#{projectLegalStatus project}
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Additional Comments about Legal Status:
+            <div .col-md-10>
+                <input type=text disabled readonly>#{projectLegalStatusComments project}
+<br>
+<fieldset>
+    <legend>
+        Project Intent
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Describe your role within the project
+            <div .col-md-10>
+                <textarea disabled readonly>#{projectUserRole project}
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Describe your project's vision and mission:
+            <div .col-md-10>
+                <textarea disabled readonly>#{projectMission project}
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Describe your project's short-term and long-term goals and deliverables:
+            <div .col-md-10>
+                <textarea disabled readonly>#{projectGoals project}
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Describe how your project will benefit from and make use of funds raised through Snowdrift.coop:
+            <div .col-md-10>
+                <textarea disabled readonly>#{projectFunds project}
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Please provide any additional information you find pertinent here (e.g. other contacts affiliated with the project and their contact info)
+            <div .col-md-10>
+                <textarea disabled readonly>#{projectOtherInfo project}
+<br>

--- a/templates/license_entry.hamlet
+++ b/templates/license_entry.hamlet
@@ -1,0 +1,38 @@
+#{lefHtml}
+<div .row>
+    <div .form-group>
+        <div .col-md-2>
+            <label>
+                License Name:
+        <div .col-md-4>
+            ^{fvInput licenseNameView}
+        <div .col-md-offset-1 .col-md-2>
+            <label>
+                Classification:
+        <div .col-md-3>
+                ^{fvInput licenseClassificationView}
+<div .row>
+    <div .form-group>
+        <div .col-md-2>
+            <label>
+                Project Types:
+        <div .col-md-2>
+            ^{fvInput licenseProjectTypeView}
+        <div .col-md-offset-3 .col-md-2>
+            <label>
+                Options:
+        <div .col-md-3>
+            ^{fvInput licenseOptionsView}
+
+<div .row>
+    <div .form-group>
+        <div .col-md-2>
+            <label>
+                Link to Legal License Text:
+        <div .col-md-4>
+            ^{fvInput licenseWebsiteView}
+        <div .col-md-offset-1 .col-md-2>
+            <label>
+                Link to Legal Logo:
+        <div .col-md-3>
+            ^{fvInput licenseIconView}

--- a/templates/project_signup.cassius
+++ b/templates/project_signup.cassius
@@ -1,0 +1,11 @@
+fieldset
+    padding: 1em
+    font: 80%/1 sans-serif
+    border-style: solid
+    border-width: 2px
+    width: inherit
+    padding:0 10px
+
+legend
+    width: auto
+    padding:0 10px

--- a/templates/project_signup.hamlet
+++ b/templates/project_signup.hamlet
@@ -1,0 +1,111 @@
+<fieldset>
+    <legend>
+        General Project Info
+    <div .row>
+        <div .form-group>
+            <div .col-md-1>
+                <label>Project Name:
+            <div .col-md-4>
+                ^{fvInput projectNameView}
+            <div .col-md-offset-1 .col-md-1>
+                <label>Website:
+            <div .col-md-5>
+                ^{fvInput projectWebsiteView}
+    <div .row>
+        <div .form-group>
+            <div .col-md-1>
+                <label>Requested Site Handle:
+            <div .col-sm-4>
+                <div .row>
+                    <div .col-md-6 align=bottom>
+                        <font size=-1>
+                            http://snowdrift.coop/p/
+                    <div .col-md-6>
+                        ^{fvInput projectHandleView}
+                <div .row>
+                    <div .col-md-12 align=top>
+                        <font size=-1>
+                            (lower case, numbers & hyphens only)
+            <div .col-md-offset-1 .col-md-1>
+                <label>Length of time project's been active:
+            <div .col-md-5>
+                ^{fvInput projectHistoryView}
+    <div .row>
+        <div .form-group>
+            <div .col-md-1>
+                <label>
+                    Select Applicable Project License(s):
+            <div .col-md-4>
+                ^{fvInput projectLicenseView}
+            <div .col-md-offset-1 .col-md-1>
+                <label>
+                    Select Applicable Project Type(s):
+            <div .col-md-4>
+                ^{fvInput projectTypeView}
+    <div .row>
+        <div .form-group>
+            <div .col-md-1>
+                <label>If Other, please describe:
+            <div .col-md-4>
+                ^{fvInput projectLicenseOtherView}
+            <div .col-md-offset-1 .col-md-1>
+                <label>If Other, please describe:
+            <div .col-md-4>
+                ^{fvInput projectTypeOtherView}
+<br>
+<fieldset>
+    <legend>
+        Legal Information
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Location Project is legally based out of:
+            <div .col-md-3>
+                ^{fvInput projectLocationView}
+            <div .col-md-offset-1 .col-md-2>
+                <label>
+                    Legal Status:
+            <div .col-md-4>
+                ^{fvInput projectLegalStatusView}
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Additional Comments about Legal Status:
+            <div .col-md-10>
+                ^{fvInput projectLegalStatusCommentsView}
+
+<br>
+<fieldset>
+    <legend>
+        Project Intent
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Describe your role within the project
+            <div .col-md-10>
+                ^{fvInput projectUserRoleView}
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Describe your project's vision and mission:
+            <div .col-md-10>
+                ^{fvInput projectMissionView}
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Describe your project's short-term and long-term goals and deliverables:
+            <div .col-md-10>
+                ^{fvInput projectGoalsView}
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Describe how your project will benefit from and make use of funds raised through Snowdrift.coop:
+            <div .col-md-10>
+                ^{fvInput projectFundsView}
+    <div .row>
+        <div .form-group>
+            <div .col-md-2>
+                <label>Please provide any additional information you find pertinent here (e.g. other contacts affiliated with the project and their contact info)
+            <div .col-md-10>
+                ^{fvInput projectOtherInfoView}
+<br>


### PR DESCRIPTION
The two new pages are created.  Note:  /admin/license doesn't have any security on it at this point, due to my not having security capabilities on the main site.  This may be something we need to discuss and fix and then add the security in so that others don't add Licenses at will.

Updated ProjectSignup page with additional Project Types and two additional fields as wolftune requested.  FYI: I am starting to work on the admin pages, which will require additional changes to the project_signup table.
