### PR TITLE
Add and fix h1 headers

### DIFF
--- a/Handler/JsLicense.hs
+++ b/Handler/JsLicense.hs
@@ -38,6 +38,8 @@ getJsLicenseR = do
     defaultLayout $ do
         setTitle "Javascript Licenses | Snowdrift.coop"
         [whamlet|
+            <h1> Javascript Licenses
+                
             <table .table id="jslicense-labels1">
                 $forall lib <- libs
                     <tr>

--- a/templates/notifications.hamlet
+++ b/templates/notifications.hamlet
@@ -1,6 +1,5 @@
 <h1>
-    <center>
-        Notifications
+    <div .text-center> Notifications
 
 $if not (null notifs)
     $forall Entity _ notif <- notifs

--- a/templates/projects.hamlet
+++ b/templates/projects.hamlet
@@ -1,5 +1,5 @@
 <h1> 
-    Projects
+    <div .text-center> Projects
 
 $if null projects
     <p> no projects to display

--- a/templates/tickets.hamlet
+++ b/templates/tickets.hamlet
@@ -1,3 +1,6 @@
+<h1>
+    <div .text-center> Tickets
+
 <form enctype=#{encType}>
     ^{formWidget}
     <input type=submit value="update view">

--- a/templates/who.hamlet
+++ b/templates/who.hamlet
@@ -1,3 +1,6 @@
+<h1>
+    <div .text-center> Project Participants
+
 $forall Entity user_id user <- members
     <hr>
     <div .row>

--- a/templates/wiki_pages.hamlet
+++ b/templates/wiki_pages.hamlet
@@ -1,3 +1,6 @@
+<h1> 
+    <div .text-center> Project Index
+
 $if null pages
     no pages to display
 $else


### PR DESCRIPTION
I made several changes:
- Added an h1 header to Handler/JsLicence.hs. I did not
  include a <div .center-text> because its inclusion did
  not seem to affect the placement of the text
- Fixed the deprecated <center> tag in templates/notifications.hamlet
- Added a centering tag in templates/projects.hamletjHandler/JsLicence.hs
- Added an h1 header with a centering tag in templates/tickets.hamlet
- Added an h1 header with a centering tag in templates/who.hamlet
- Added an h1 header with a centering tag in templates/wiki_pages.hamlet.hamlet
  A possible next step here might be to have each project's name
  generated dynamically, so it reads "ProjectName Index"

This patch should enable the closing of this ticket: https://github.com/dlthomas/snowdrift/issues/193
