### PR TITLE
Snowdrift.cabal now has "AGPL-3" as License

### DIFF
--- a/Snowdrift.cabal
+++ b/Snowdrift.cabal
@@ -1,6 +1,6 @@
 name:              Snowdrift
 version:           0.1.2
-license:           OtherLicense
+license:           AGPL-3
 license-file:      LICENSE
 author:            David L. L. Thomas
 maintainer:        Snowdrift.coop


### PR DESCRIPTION
(Instead of "OtherLicense")
