### PR TITLE
Build on Windows

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -16,7 +16,6 @@ import           Control.Concurrent.STM               (atomically, newTChanIO, t
 import           Control.Monad.Logger                 (runLoggingT, runStderrLoggingT)
 import           Control.Monad.Reader
 import           Control.Monad.Trans.Resource
-import           Data.ByteString                      (ByteString)
 import           Data.Default                         (def)
 import qualified Data.List                            as L
 import           Data.Text                            as T
@@ -30,10 +29,9 @@ import           Network.Wai.Middleware.RequestLogger ( mkRequestLogger, outputF
 import           Network.Wai.Logger                   (clockDateCacher)
 import qualified Network.Wai.Middleware.RequestLogger as RequestLogger
 import           System.Directory
-import           System.Environment                   (lookupEnv)
+import           System.Environment
 import           System.Log.FastLogger                (newStdoutLoggerSet, defaultBufSize, flushLogStr)
 import           System.IO                            (stderr)
-import           System.Posix.Env.ByteString
 import           Yesod.Core.Types                     (loggerSet, Logger (Logger))
 import           Yesod.Default.Config
 import           Yesod.Default.Handlers
@@ -84,13 +82,13 @@ version = $(mkVersion)
 mkYesodDispatch "App" resourcesApp
 
 -- probably not thread safe
-withEnv :: (MonadIO m) => ByteString -> ByteString -> m a -> m a
+withEnv :: (MonadIO m) => String -> String -> m a -> m a
 withEnv k v action = do
-    original <- liftIO $ getEnv k
+    original <- liftIO $ lookupEnv k
 
-    liftIO $ setEnv k v True
+    liftIO $ setEnv k v
     result <- action
-    liftIO $ maybe (unsetEnv k) (\v' -> setEnv k v' True) original
+    liftIO $ maybe (unsetEnv k) (setEnv k) original
 
     return result
 
@@ -244,7 +242,7 @@ deprecatedApplyManualMigrations = do
 -- storing the necessary sql statements to commit and share.
 saveUnsafeMigrations :: (MonadIO m, Functor m) => ReaderT SqlBackend m ()
 saveUnsafeMigrations = do
-    unsafe <- (L.filter fst) <$> parseMigration' migrateAll
+    unsafe <- L.filter fst <$> parseMigration' migrateAll
     unless (L.null $ L.map snd unsafe) $ do
         liftIO $ T.writeFile filename $ T.unlines $ L.map ((`snoc` ';') . snd) unsafe
         liftIO $ mapM_ (T.hPutStrLn stderr) unsafeMigMessages

--- a/Snowdrift.cabal
+++ b/Snowdrift.cabal
@@ -18,7 +18,7 @@ Flag dev
 
 Flag merge
     Description:   Similar to dev, except with -Werror added.
-    Default:        False
+    Default:       False
 
 Flag library-only
     Description:   Build for use with "yesod devel"
@@ -215,9 +215,9 @@ library
                  , time
                  , titlecase
                  , transformers
-                 , unix
                  , wai-extra
                  , wai-logger
+                 , warp
                  , yaml
                  -- extra caution for our primary dependency on Yesod
                  , yesod >= 1.4 && < 1.5


### PR DESCRIPTION
Removed dependency on `unix` package (does not build on Windows) as the cross-plaform environment get, set, unset functions from it are found in the latest `base` package and supported on all 3 main consumer operating systems. This allows it to be built on Windows, will add more details to the guide later.
