### PR TITLE
Fix SD-174

### DIFF
--- a/tests/WikiTest.hs
+++ b/tests/WikiTest.hs
@@ -36,3 +36,10 @@ wikiSpecs =
             loginAs TestUser
             editWiki snowdrift LangEn "wiki-test" "wiki test: edit page" "testing"
         |]
+
+        yit "cannot create an existent wiki page" $ [marked|
+            loginAs TestUser
+            newWiki snowdrift LangEn "wiki-foo" "wiki foo: new page"
+            get $ NewWikiR snowdrift LangEn "wiki-foo"
+            statusIs 400
+        |]


### PR DESCRIPTION
For reference: https://snowdrift.coop/p/snowdrift/w/en/wiki/c/966.

Snowdrift will now throw a 400 error on the GET request if the user tries to do either of the following things:
- Create a wiki page on a nonexistent project
- Create a wiki page that already exists

I added a test for this as well.
