### PR TITLE
Allow a user to click a tag to see all the issues that have that tag in the project.

### DIFF
--- a/config/routes
+++ b/config/routes
@@ -105,6 +105,7 @@
 /p/#Text/pledge                              UpdatePledgeR            GET POST
 /p/#Text/t                                   TicketsR                 GET
 /p/#Text/t/#TicketId                         TicketR                  GET
+/p/#Text/t/tags/#Text                        TicketsByTag             GET
 /p/#Text/transactions                        ProjectTransactionsR     GET
 /p/#Text/volunteer                           VolunteerR               GET POST
 /p/#Text/w                                   WikiPagesR               GET

--- a/src/Model/Project.hs
+++ b/src/Model/Project.hs
@@ -1,5 +1,6 @@
 module Model.Project
-    ( ProjectSummary(..)
+    ( TaggedTicket
+    , ProjectSummary(..)
     , UpdateProject(..)
     , fetchPublicProjectsDB
     , fetchProjectDB
@@ -30,6 +31,7 @@ module Model.Project
     , projectComputeShareValue
     , projectNameWidget
     , summarizeProject
+    , tags
     , updateShareValue
     , updateUserPledge
     -- * Balancing/deactivating pledges
@@ -93,9 +95,9 @@ data UpdateProject = UpdateProject
     , updateProjectLogo        :: Maybe Text
     } deriving Show
 
-newtype TaggedTicket = TaggedTicket ( (Entity Ticket)
+newtype TaggedTicket = TaggedTicket ((Entity Ticket)
                                     , Bool  -- claimed?
-                                    , [AnnotatedTag] )
+                                    , [AnnotatedTag])
 
 instance Issue TaggedTicket where
     issueWidget (TaggedTicket ((Entity ticket_id ticket),_,tags)) =
@@ -145,6 +147,9 @@ ticketToOrderable (TaggedTicket ((Entity _ ticket), is_claimed, tags)) =
     get_named_ts name = error $ "Unrecognized time name " ++ T.unpack name
 
     search_literal str = (not . null . T.breakOnAll str) (ticketName ticket)
+
+tags :: TaggedTicket -> [AnnotatedTag]
+tags (TaggedTicket (Entity _ ticket, is_claimed, tags)) = tags
 
 --------------------------------------------------------------------------------
 -- Database actions


### PR DESCRIPTION
I wanted to allow snowdrift to support similar functionality to github's 'view issues by label' feature. For example: https://github.com/snowdriftcoop/snowdrift/labels/bug

**Done**
- Make it possible to link to all the tags with a given label. A new route has been exposed (/p/#Text/t/tags/#Text). Concrete example: /p/snowdrift/t/tags/pish)

**To do**
- Make tags clickable on the issues page to go to the above route. This could be done as a separate pull request if desired.
