### PR TITLE
Remove ide-haskell-stack from Atom packages

### DIFF
--- a/TEXTEDITORS.md
+++ b/TEXTEDITORS.md
@@ -34,7 +34,7 @@ install ide-haskell for Atom:
 
 * Run `stack build ghc-mod hlint stylish-haskell`
 * Install the relevant Atom packages:
-  `apm install language-haskell haskell-ghc-mod ide-haskell autocomplete-haskell`
+  `apm install language-haskell haskell-ghc-mod ide-haskell autocomplete-haskell ide-haskell-cabal`
 * Make sure to check "Stack sandbox" in the haskell-ghc-mod settings
 * *Note: ghc-mod will fail if it sees a dist/ directory which is made when you
   run snowdrift via `stack exec yesod devel`, so until yesod-bin is updated to

--- a/TEXTEDITORS.md
+++ b/TEXTEDITORS.md
@@ -34,7 +34,7 @@ install ide-haskell for Atom:
 
 * Run `stack build ghc-mod hlint stylish-haskell`
 * Install the relevant Atom packages:
-  `apm install language-haskell haskell-ghc-mod ide-haskell autocomplete-haskell ide-haskell-stack`
+  `apm install language-haskell haskell-ghc-mod ide-haskell autocomplete-haskell`
 * Make sure to check "Stack sandbox" in the haskell-ghc-mod settings
 * *Note: ghc-mod will fail if it sees a dist/ directory which is made when you
   run snowdrift via `stack exec yesod devel`, so until yesod-bin is updated to


### PR DESCRIPTION
It looks like the `ide-haskell-stack` Atom package is no longer available.

See [atom-haskell](https://atom.io/users/atom-haskell)'s Packages [here](https://atom.io/users/atom-haskell/packages), and also a screenshot from my machine:

![image](https://cloud.githubusercontent.com/assets/287532/15359550/7df5b8c6-1d12-11e6-92ff-cb0c0138d743.png)

Note that the `ide-haskell-stack` package is no longer available on apm. :confused: 
