### PR TITLE
Redirect user to /auth/verify-account after inputting an invalid token

### DIFF
--- a/website/src/AuthSite.hs
+++ b/website/src/AuthSite.hs
@@ -478,7 +478,7 @@ runToken tok = do
             -- may want to modify this as well (or make it more
             -- accessible to front end devs).
             lift $ alertWarning "Uh oh, your token appears to be invalid!"
-            redirectParent' LoginR
+            redirectParent' VerifyAccountR
         Just _ -> do
             lift $ alertSuccess "You are all set! Log in to continue."
             redirectParent' LoginR


### PR DESCRIPTION
As discussed in #331.