### PR TITLE
Redirect to the ult-destination when a user is booted to /auth/login.

### DIFF
--- a/website/src/AuthSite.hs
+++ b/website/src/AuthSite.hs
@@ -344,7 +344,7 @@ postLoginR = do
         (\u -> do
             priviligedLogin u
             alertInfo "Welcome"
-            redirect =<< (postLoginRoute <$> getYesod))
+            redirectUltDest =<< (postLoginRoute <$> getYesod))
 
 formResult :: (Yesod master
               ,MonadTrans child)


### PR DESCRIPTION
Yesod handily passes along an "ultimate destination", which we can use to redirect the user back to the page that they originally requested. To see this in action, visit `/payment-info` while logged out. After logging in, the user is now redirected to `/payment-info` instead of `/dashboard`.