### PR TITLE
Nix build

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+eval "$(lorri direnv)"

--- a/BUILD.md
+++ b/BUILD.md
@@ -5,6 +5,18 @@ Snowdrift has been built successfully on many GNU/Linux distros and on macOS.
 Windows and \*BSD distributions are not currently supported, but we will assist
 any efforts to add such support. See below for partial setup instructions.
 
+## Get the Snowdrift code
+
+Our primary repository is at [GitLab], and our instructions assume that repository. For convenience and redundancy, we also mirror at [GitHub].
+
+From within your preferred directory, get the code with:
+
+    git clone https://gitlab.com/snowdrift/snowdrift.git
+
+Change to the new snowdrift directory:
+
+    cd snowdrift
+
 ## Install System Dependencies
 
 [Git], [PostgreSQL], [Stack], and [Make] are the only dependencies needed at the
@@ -71,16 +83,14 @@ to use a version of ghc that compiles without PIE. We were unable to find a way
 to set this configuration *just* for Snowdrift, however we don't believe making
 this change will cause any issues with compiling other Haskell projects.
 
-### NixOS
+### NixOS or Nix on Linux, MacOS or WSL
 
-Use `nix-shell` to provide Stack and the Yesod executable:
-
-    nix-shell -p stack haskellPackages.yesod-bin
-
-Add the following to `~/.stack/config.yaml`:
+Change `stack.yaml` to enable nix:
 
     nix:
       enable: true
+
+Run `nix-shell` in the root of the project. You will have to build, test and run the server inside the shell. You should also launch your editor from inside the nix-shell.
 
 ### \*BSD
 
@@ -107,22 +117,12 @@ With brew, install the core dependencies:
 
 **Status:** We welcome testing but do not officially support Windows.
 
+A way to get the project built on Windows is by installing Windows Subsystem for Linux (WSL), install Nix in it and then follow the Nix setup from above.
+
 In the past, we have had only partial success running on Windows. We know that
 our development database scripts won't work on Windows because they use UNIX
 sockets. We welcome any patches, feedback, or Postgres-on-Windows help to get an
 alternative working.
-
-## Get the Snowdrift code
-
-Our primary repository is at [GitLab], and our instructions assume that repository. For convenience and redundancy, we also mirror at [GitHub].
-
-From within your preferred directory, get the code with:
-
-    git clone https://gitlab.com/snowdrift/snowdrift.git
-
-Change to the new snowdrift directory:
-
-    cd snowdrift
 
 ## Run the tests
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+with import (fetchTarball https://github.com/NixOS/nixpkgs/archive/83b35508c6491103cd16a796758e07417a28698b.tar.gz) {};
+let ghc = haskell.compiler.ghc802;
+in haskell.lib.buildStackProject {
+  inherit ghc;
+  name = "myEnv";
+  buildInputs = [ postgresql gmp libpqxx gnumake openssl zlib.dev zlib.out ];
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,6 +24,7 @@ extra-deps:
   - git: https://github.com/aloiscochard/codex.git
     commit: 0d59fe5099136015912e13a4c1ea573c5fd7f2ff
 nix:
+  enable: false
   pure: false
   packages:
     - ncurses


### PR DESCRIPTION
* created nix-shell file that can be used for building the project using Nix on Linux, MacOS and Windows WSL.
* added `.envrc` file for usage with Nix nix-shell lorri/target
* updated documentation on how to setup the development environment with Nix